### PR TITLE
Fix braille plot y-axis scaling

### DIFF
--- a/demos/plot/main.go
+++ b/demos/plot/main.go
@@ -18,8 +18,10 @@ func main() {
 		data[0] = make([]float64, n)
 		data[1] = make([]float64, n)
 		for i := 0; i < n; i++ {
-			data[0][i] = 1 + math.Sin(float64(i)/5)
-			data[1][i] = 1 + math.Cos(float64(i)/5)
+			data[0][i] = 1 + math.Sin(float64(i+1)/5)
+			// Avoid taking Cos(0) because it creates a high point of 2 that
+			// will never be hit again and makes the graph look a little funny
+			data[1][i] = 1 + math.Cos(float64(i+1)/5)
 		}
 		return data
 	}()

--- a/plot.go
+++ b/plot.go
@@ -255,25 +255,15 @@ func (plot *Plot) drawDotMarkerToScreen(screen tcell.Screen) {
 }
 
 func (plot *Plot) drawBrailleMarkerToScreen(screen tcell.Screen) {
-	var cellMaxY int
-
 	x, y, width, height := plot.getChartAreaRect()
 
 	plot.calcBrailleLines()
 
-	for point := range plot.getBrailleCells() {
-		if point.Y > cellMaxY {
-			cellMaxY = point.Y
-		}
-	}
-
-	diffMAxY := y + height - cellMaxY - 1
-
 	// print to screen
 	for point, cell := range plot.getBrailleCells() {
 		style := tcell.StyleDefault.Background(plot.GetBackgroundColor()).Foreground(cell.color)
-		if point.X < x+width && point.Y+diffMAxY < y+height {
-			tview.PrintJoinedSemigraphics(screen, point.X, point.Y+diffMAxY, cell.cRune, style)
+		if point.X < x+width && point.Y < y+height {
+			tview.PrintJoinedSemigraphics(screen, point.X, point.Y, cell.cRune, style)
 		}
 	}
 }
@@ -288,7 +278,7 @@ func (plot *Plot) calcBrailleLines() {
 			continue
 		}
 
-		previousHeight := int((line[1] / maxVal) * float64(height-1))
+		previousHeight := int((line[0] / maxVal) * float64(height-1))
 
 		for j, val := range line[1:] {
 			lheight := int((val / maxVal) * float64(height-1))


### PR DESCRIPTION
Braille Mode line charts didn't draw the dots in the correct y-axis location. For example, I created a chart with data values between 1 and 2 stepping by .1 (1, 1.1, 1.2 ... 2.0). The PlotMarkerDot mode accurately displayed the dots in the 1 - 2 range on the Y axis. However, when using PlotMarkerBraille mode, the dots appeared between the range of 0 and 1. The gap is much larger if the the data values are bigger (for example, 100 to 101 stepping by .1)

I modified the braille plotting code to more closely match the termui library implementation, which didn't have the problem.

Graphs are now displaying as expected.

Signed-off-by: Aaron DeMille <ajdemille2@gmail.com>
