### PR TITLE
Auto set the Y axis label width

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,6 +1,6 @@
 # Contributing To Tvxwidgets
 
-We'd love your contribtion on the project!
+We'd love your contribution on the project!
 
 ## Developer Certificate of Origin
 


### PR DESCRIPTION
The Y axis label width was hard coded to 4 with 2 decimal places. This caused any number larger than 1000 to be truncated.

The Y axis label width is now based on the maximum value in the data set, allowing enough characters for the whole number along with 2 decimal places.