### PR TITLE
ignore math.NaN() values when drawing plots

### DIFF
--- a/plot.go
+++ b/plot.go
@@ -3,6 +3,7 @@ package tvxwidgets
 import (
 	"fmt"
 	"image"
+	"math"
 	"strconv"
 	"sync"
 
@@ -292,6 +293,10 @@ func (plot *Plot) drawDotMarkerToScreen(screen tcell.Screen) {
 
 			for j := 0; j < len(line) && j*plotHorizontalScale < width; j++ {
 				val := line[j]
+				if math.IsNaN(val) {
+					continue
+				}
+
 				lheight := int((val / plot.maxVal) * float64(height-1))
 
 				if (x+(j*plotHorizontalScale) < x+width) && (y+height-1-lheight < y+height) {
@@ -305,6 +310,10 @@ func (plot *Plot) drawDotMarkerToScreen(screen tcell.Screen) {
 			style := tcell.StyleDefault.Background(plot.GetBackgroundColor()).Foreground(plot.lineColors[i])
 
 			for j, val := range line {
+				if math.IsNaN(val) {
+					continue
+				}
+
 				lheight := int((val / plot.maxVal) * float64(height-1))
 
 				if (x+(j*plotHorizontalScale) < x+width) && (y+height-1-lheight < y+height) {
@@ -341,6 +350,10 @@ func (plot *Plot) calcBrailleLines() {
 		previousHeight := int((line[0] / plot.maxVal) * float64(height-1))
 
 		for j, val := range line[1:] {
+			if math.IsNaN(val) {
+				continue
+			}
+
 			lheight := int((val / plot.maxVal) * float64(height-1))
 
 			plot.setBrailleLine(

--- a/plot.go
+++ b/plot.go
@@ -353,9 +353,11 @@ func (plot *Plot) calcBrailleLines() {
 
 		lastValWasNaN := math.IsNaN(line[0])
 		previousHeight := 0
+
 		if !lastValWasNaN {
 			previousHeight = calcDataPointHeight(line[0], plot.maxVal, 0, height)
 		}
+
 		for j, val := range line[1:] {
 			if math.IsNaN(val) {
 				if !lastValWasNaN {
@@ -370,12 +372,14 @@ func (plot *Plot) calcBrailleLines() {
 				}
 
 				lastValWasNaN = true
+
 				continue
 			}
 
 			if lastValWasNaN {
 				previousHeight = calcDataPointHeight(val, plot.maxVal, 0, height)
 				lastValWasNaN = false
+
 				continue
 			}
 

--- a/plot.go
+++ b/plot.go
@@ -358,6 +358,17 @@ func (plot *Plot) calcBrailleLines() {
 		}
 		for j, val := range line[1:] {
 			if math.IsNaN(val) {
+				if !lastValWasNaN {
+					// last data point was single valid data point
+					plot.setBraillePoint(
+						image.Pt(
+							(x+(j*plotHorizontalScale))*2, //nolint:gomnd
+							(y+height-previousHeight-1)*4, //nolint:gomnd
+						),
+						plot.lineColors[i],
+					)
+				}
+
 				lastValWasNaN = true
 				continue
 			}

--- a/sparkline.go
+++ b/sparkline.go
@@ -1,6 +1,7 @@
 package tvxwidgets
 
 import (
+	"math"
 	"sync"
 
 	"github.com/gdamore/tcell/v2"
@@ -40,13 +41,18 @@ func (sl *Sparkline) Draw(screen tcell.Screen) {
 	}
 
 	maxVal := getMaxFloat64FromSlice(sl.data)
-	if maxVal == 0 {
+	if maxVal < 0 {
 		return
 	}
 
 	// print lines
 	for i := 0; i < len(sl.data) && i+x < x+width; i++ {
 		data := sl.data[i]
+
+		if math.IsNaN(data) {
+			continue
+		}
+
 		dHeight := int((data / maxVal) * float64(barHeight))
 
 		sparkChar := barsRune[len(barsRune)-1]

--- a/utils.go
+++ b/utils.go
@@ -110,8 +110,11 @@ func getMaxFloat64FromSlice(slice []float64) float64 {
 		return 0
 	}
 
-	max := slice[0]
-	for i := 1; i < len(slice); i++ {
+	max := -1.0
+	for i := 0; i < len(slice); i++ {
+		if math.IsNaN(slice[i]) {
+			continue
+		}
 		if slice[i] > max {
 			max = slice[i]
 		}

--- a/utils.go
+++ b/utils.go
@@ -1,6 +1,7 @@
 package tvxwidgets
 
 import (
+	"math"
 	"strings"
 
 	"github.com/gdamore/tcell/v2"
@@ -83,6 +84,10 @@ func getMaxFloat64From2dSlice(slices [][]float64) float64 {
 
 	for _, slice := range slices {
 		for _, val := range slice {
+			if math.IsNaN(val) {
+				continue
+			}
+
 			if !maxIsInit {
 				maxIsInit = true
 				max = val

--- a/utils.go
+++ b/utils.go
@@ -111,10 +111,12 @@ func getMaxFloat64FromSlice(slice []float64) float64 {
 	}
 
 	max := -1.0
+
 	for i := 0; i < len(slice); i++ {
 		if math.IsNaN(slice[i]) {
 			continue
 		}
+
 		if slice[i] > max {
 			max = slice[i]
 		}


### PR DESCRIPTION
Drawing graphs with "gaps" in the data currently results in an ugly "0 line":

![image](https://github.com/user-attachments/assets/5d86cb17-2a1d-453d-aca8-14843f250fa6)

This PR simply ignores values that match `math.IsNaN(val)`, leaving an actual gap in the drawn line:

![image](https://github.com/user-attachments/assets/9e1b7318-29eb-477c-9f04-2450812670f3)


Interestingly this behavior only affects the "braille" type line plot. Not sure whats different about the "dot" mode that makes it work anyway.


I tried to run tests, but it seems like running tests in this repo requires an extensive local setup involving multiple external packages, so I wasn't able to get it running. Let me know if I need to add anything else.

PS: Ignore the bad braille rendering, its caused by the IntelliJ integrated shell. Looks much better in an actual shell.