### PR TITLE
fix: align minimum-value data points with the Y-axis zero label

### DIFF
--- a/plot.go
+++ b/plot.go
@@ -319,18 +319,21 @@ func (plot *Plot) drawXAxisLabelsToScreen(
 	// overlap with each other
 	for i, label := range labelMap {
 		var expectedLabelWidth int
+
 		var currentLabelStart int
-		switch {
-		case i == 0:
+
+		switch i {
+		case 0:
 			// First label anchors at the data point column with no centering.
 			currentLabelStart = 0
-		case i == maxDataPoints-1:
-			expectedLabelWidth = len(label) + plotXAxisLabelsGap/2
-			currentLabelStart = i - expectedLabelWidth/2
+		case maxDataPoints - 1:
+			expectedLabelWidth = len(label) + plotXAxisLabelsGap/2 //nolint:mnd
+			currentLabelStart = i - expectedLabelWidth/2           //nolint:mnd
 		default:
 			expectedLabelWidth = len(label) + plotXAxisLabelsGap
 			currentLabelStart = i - expectedLabelWidth/2 //nolint:mnd
 		}
+
 		labelStartMap[i] = currentLabelStart
 	}
 
@@ -347,17 +350,19 @@ func (plot *Plot) drawXAxisLabelsToScreen(
 		}
 
 		rawLabel := labelMap[i]
+
 		var labelWithGap string
 
-		switch {
-		case i == 0:
+		switch i {
+		case 0:
 			// First label: no leading gap, trailing gap only.
-			labelWithGap = rawLabel + strings.Repeat(gapRune, plotXAxisLabelsGap/2)
-		case i == maxDataPoints-1:
+			labelWithGap = rawLabel + strings.Repeat(gapRune, plotXAxisLabelsGap/2) //nolint:mnd
+		case maxDataPoints - 1:
 			// Last label: leading gap only, no trailing gap so it doesn't overflow the right edge.
-			labelWithGap = strings.Repeat(gapRune, plotXAxisLabelsGap/2) + rawLabel
+			labelWithGap = strings.Repeat(gapRune, plotXAxisLabelsGap/2) + rawLabel //nolint:mnd
 		default:
-			labelWithGap = strings.Repeat(gapRune, plotXAxisLabelsGap/2) + rawLabel + strings.Repeat(gapRune, plotXAxisLabelsGap/2)
+			half := strings.Repeat(gapRune, plotXAxisLabelsGap/2) //nolint:mnd
+			labelWithGap = half + rawLabel + half
 		}
 
 		expectedLabelWidth := len(labelWithGap)
@@ -444,6 +449,7 @@ func (plot *Plot) drawYAxisLabelsToScreen(screen tcell.Screen, plotYAxisLabelsWi
 func (plot *Plot) drawDotMarkerToScreen(screen tcell.Screen) {
 	x, y, width, height := plot.GetPlotRect()
 	chartData := plot.getData()
+
 	switch plot.ptype {
 	case PlotTypeLineChart:
 		for i, line := range chartData {
@@ -502,6 +508,7 @@ func (plot *Plot) drawBrailleMarkerToScreen(screen tcell.Screen) {
 				continue
 			}
 		}
+
 		style := tcell.StyleDefault.Background(plot.GetBackgroundColor()).Foreground(cell.color)
 		if point.X < x+width && point.Y <= y+height {
 			tview.PrintJoinedSemigraphics(screen, point.X, point.Y, cell.cRune, style)

--- a/plot.go
+++ b/plot.go
@@ -73,6 +73,7 @@ type Plot struct {
 	yAxisAutoScaleMin  bool
 	yAxisAutoScaleMax  bool
 	brailleCellMap     map[image.Point]brailleCell
+	xAxisTickCols      map[int]struct{} // screen columns where X axis tick triangles are drawn
 	mu                 sync.Mutex
 }
 
@@ -110,6 +111,7 @@ func (plot *Plot) Draw(screen tcell.Screen) {
 		plot.drawBrailleMarkerToScreen(screen)
 	}
 }
+
 // SetRect sets rect for this primitive.
 func (plot *Plot) SetRect(x, y, width, height int) {
 	plot.Box.SetRect(x, y, width, height)
@@ -249,6 +251,8 @@ func (plot *Plot) drawAxesToScreen(screen tcell.Screen) {
 		return
 	}
 
+	plot.xAxisTickCols = make(map[int]struct{})
+
 	x, y, width, height := plot.GetInnerRect()
 	plotYAxisLabelsWidth := plot.getYAxisLabelsWidth()
 
@@ -314,14 +318,19 @@ func (plot *Plot) drawXAxisLabelsToScreen(
 	// Note: not all of these labels will be printed, as they would
 	// overlap with each other
 	for i, label := range labelMap {
-		expectedLabelWidth := len(label)
-		if i == 0 {
-			expectedLabelWidth += plotXAxisLabelsGap / 2 //nolint:mnd
-		} else {
-			expectedLabelWidth += plotXAxisLabelsGap
+		var expectedLabelWidth int
+		var currentLabelStart int
+		switch {
+		case i == 0:
+			// First label anchors at the data point column with no centering.
+			currentLabelStart = 0
+		case i == maxDataPoints-1:
+			expectedLabelWidth = len(label) + plotXAxisLabelsGap/2
+			currentLabelStart = i - expectedLabelWidth/2
+		default:
+			expectedLabelWidth = len(label) + plotXAxisLabelsGap
+			currentLabelStart = i - expectedLabelWidth/2 //nolint:mnd
 		}
-
-		currentLabelStart := i - int(math.Round(float64(expectedLabelWidth)/2)) //nolint:mnd
 		labelStartMap[i] = currentLabelStart
 	}
 
@@ -338,12 +347,17 @@ func (plot *Plot) drawXAxisLabelsToScreen(
 		}
 
 		rawLabel := labelMap[i]
-		labelWithGap := rawLabel
+		var labelWithGap string
 
-		if i == 0 {
-			labelWithGap += strings.Repeat(gapRune, plotXAxisLabelsGap/2) //nolint:mnd
-		} else {
-			labelWithGap = strings.Repeat(gapRune, plotXAxisLabelsGap/2) + labelWithGap + strings.Repeat(gapRune, plotXAxisLabelsGap/2) //nolint:lll,mnd
+		switch {
+		case i == 0:
+			// First label: no leading gap, trailing gap only.
+			labelWithGap = rawLabel + strings.Repeat(gapRune, plotXAxisLabelsGap/2)
+		case i == maxDataPoints-1:
+			// Last label: leading gap only, no trailing gap so it doesn't overflow the right edge.
+			labelWithGap = strings.Repeat(gapRune, plotXAxisLabelsGap/2) + rawLabel
+		default:
+			labelWithGap = strings.Repeat(gapRune, plotXAxisLabelsGap/2) + rawLabel + strings.Repeat(gapRune, plotXAxisLabelsGap/2)
 		}
 
 		expectedLabelWidth := len(labelWithGap)
@@ -355,6 +369,13 @@ func (plot *Plot) drawXAxisLabelsToScreen(
 				// if we omit the last gap, it fits, so we draw that before stopping
 				labelWithoutGap := labelWithGap[:len(labelWithGap)-1]
 				plot.printXAxisLabel(screen, labelWithoutGap, initialOffset+labelStart, y+height-plotXAxisLabelsHeight)
+				tview.Print(screen,
+					string('\u25BE'),
+					initialOffset+i,
+					y+height-plotXAxisLabelsHeight-1,
+					1, tview.AlignLeft,
+					plot.axesColor)
+				plot.xAxisTickCols[initialOffset+i] = struct{}{}
 			}
 
 			break
@@ -362,6 +383,15 @@ func (plot *Plot) drawXAxisLabelsToScreen(
 
 		lastUsedLabelEnd = labelStart + expectedLabelWidth
 		plot.printXAxisLabel(screen, labelWithGap, initialOffset+labelStart, y+height-plotXAxisLabelsHeight)
+
+		// Draw a small solid downward triangle on the axis line at the exact data point column.
+		tview.Print(screen,
+			string('\u25BE'),
+			initialOffset+i,
+			y+height-plotXAxisLabelsHeight-1,
+			1, tview.AlignLeft,
+			plot.axesColor)
+		plot.xAxisTickCols[initialOffset+i] = struct{}{}
 	}
 }
 
@@ -396,6 +426,17 @@ func (plot *Plot) drawYAxisLabelsToScreen(screen tcell.Screen, plotYAxisLabelsWi
 			y+height-(i*(plotYAxisLabelsGap+1))-2, //nolint:mnd
 			plotYAxisLabelsWidth,
 			tview.AlignLeft, plot.axesLabelColor)
+
+		// Draw a tick mark on the Y axis at this label's row (skip i=0 where the
+		// corner rune already anchors the bottom). The tick joins with the vertical
+		// axis line via semigraphics to produce '┤'.
+		if i > 0 {
+			tview.PrintJoinedSemigraphics(screen,
+				x+plotYAxisLabelsWidth,
+				y+height-(i*(plotYAxisLabelsGap+1))-2, //nolint:mnd
+				tview.BoxDrawingsLightVerticalAndLeft,
+				tcell.StyleDefault.Background(plot.GetBackgroundColor()).Foreground(plot.axesColor))
+		}
 	}
 }
 
@@ -453,7 +494,14 @@ func (plot *Plot) drawBrailleMarkerToScreen(screen tcell.Screen) {
 	plot.calcBrailleLines()
 
 	// print to screen
+	axisRow := y + height // screen row of the X axis line
 	for point, cell := range plot.getBrailleCells() {
+		// Don't overwrite X axis tick triangles with braille characters.
+		if point.Y == axisRow {
+			if _, isTick := plot.xAxisTickCols[point.X]; isTick {
+				continue
+			}
+		}
 		style := tcell.StyleDefault.Background(plot.GetBackgroundColor()).Foreground(cell.color)
 		if point.X < x+width && point.Y <= y+height {
 			tview.PrintJoinedSemigraphics(screen, point.X, point.Y, cell.cRune, style)
@@ -532,7 +580,7 @@ func (plot *Plot) calcBrailleLines() {
 func calcBraillePoint(x, j, y, maxY, height int) image.Point {
 	return image.Pt(
 		(x+(j*plotHorizontalScale))*2, //nolint:mnd
-		(y+maxY-height)*4,           //nolint:mnd
+		(y+maxY-height)*4,             //nolint:mnd
 	)
 }
 

--- a/plot.go
+++ b/plot.go
@@ -101,6 +101,7 @@ func NewPlot() *Plot {
 // Draw draws this primitive onto the screen.
 func (plot *Plot) Draw(screen tcell.Screen) {
 	plot.DrawForSubclass(screen, plot)
+	plot.drawAxesToScreen(screen)
 
 	switch plot.marker {
 	case PlotMarkerDot:
@@ -108,10 +109,7 @@ func (plot *Plot) Draw(screen tcell.Screen) {
 	case PlotMarkerBraille:
 		plot.drawBrailleMarkerToScreen(screen)
 	}
-
-	plot.drawAxesToScreen(screen)
 }
-
 // SetRect sets rect for this primitive.
 func (plot *Plot) SetRect(x, y, width, height int) {
 	plot.Box.SetRect(x, y, width, height)
@@ -227,6 +225,7 @@ func (plot *Plot) GetPlotRect() (int, int, int, int) {
 	} else {
 		x++
 		width--
+		height--
 	}
 
 	return x, y, width, height
@@ -404,8 +403,6 @@ func (plot *Plot) drawYAxisLabelsToScreen(screen tcell.Screen, plotYAxisLabelsWi
 func (plot *Plot) drawDotMarkerToScreen(screen tcell.Screen) {
 	x, y, width, height := plot.GetPlotRect()
 	chartData := plot.getData()
-	verticalOffset := -plot.minVal
-
 	switch plot.ptype {
 	case PlotTypeLineChart:
 		for i, line := range chartData {
@@ -417,13 +414,13 @@ func (plot *Plot) drawDotMarkerToScreen(screen tcell.Screen) {
 					continue
 				}
 
-				lheight := int(((val + verticalOffset) / plot.maxVal) * float64(height-1))
+				lheight := calcDataPointHeight(val, plot.maxVal, plot.minVal, height)
 				if lheight > height {
 					continue
 				}
 
-				if (x+(j*plotHorizontalScale) < x+width) && (y+height-1-lheight < y+height) {
-					tview.PrintJoinedSemigraphics(screen, x+(j*plotHorizontalScale), y+height-1-lheight, plot.dotMarkerRune, style)
+				if (x+(j*plotHorizontalScale) < x+width) && (y+height-lheight <= y+height) {
+					tview.PrintJoinedSemigraphics(screen, x+(j*plotHorizontalScale), y+height-lheight, plot.dotMarkerRune, style)
 				}
 			}
 		}
@@ -437,13 +434,13 @@ func (plot *Plot) drawDotMarkerToScreen(screen tcell.Screen) {
 					continue
 				}
 
-				lheight := int(((val + verticalOffset) / plot.maxVal) * float64(height-1))
+				lheight := calcDataPointHeight(val, plot.maxVal, plot.minVal, height)
 				if lheight > height {
 					continue
 				}
 
-				if (x+(j*plotHorizontalScale) < x+width) && (y+height-1-lheight < y+height) {
-					tview.PrintJoinedSemigraphics(screen, x+(j*plotHorizontalScale), y+height-1-lheight, plot.dotMarkerRune, style)
+				if (x+(j*plotHorizontalScale) < x+width) && (y+height-lheight <= y+height) {
+					tview.PrintJoinedSemigraphics(screen, x+(j*plotHorizontalScale), y+height-lheight, plot.dotMarkerRune, style)
 				}
 			}
 		}
@@ -458,13 +455,17 @@ func (plot *Plot) drawBrailleMarkerToScreen(screen tcell.Screen) {
 	// print to screen
 	for point, cell := range plot.getBrailleCells() {
 		style := tcell.StyleDefault.Background(plot.GetBackgroundColor()).Foreground(cell.color)
-		if point.X < x+width && point.Y < y+height {
+		if point.X < x+width && point.Y <= y+height {
 			tview.PrintJoinedSemigraphics(screen, point.X, point.Y, cell.cRune, style)
 		}
 	}
 }
 
 func calcDataPointHeight(val, maxVal, minVal float64, height int) int {
+	if maxVal == minVal {
+		return 0
+	}
+
 	return int(((val - minVal) / (maxVal - minVal)) * float64(height-1))
 }
 
@@ -531,7 +532,7 @@ func (plot *Plot) calcBrailleLines() {
 func calcBraillePoint(x, j, y, maxY, height int) image.Point {
 	return image.Pt(
 		(x+(j*plotHorizontalScale))*2, //nolint:mnd
-		(y+maxY-height-1)*4,           //nolint:mnd
+		(y+maxY-height)*4,           //nolint:mnd
 	)
 }
 


### PR DESCRIPTION
## Problem

Data points at the minimum value (typically `0`) were rendered one row above the X axis, while the `0` label sits on the axis line itself. This creates a visible gap between the chart floor and the legend floor.

Ideally a data point with value `0` should appear on the same row as the `0` label — the axis line is the visual representation of zero, and aligning data points with it makes the chart easier to read.

Also added "ticks" to the x & y axis. If you want I can refactor so the user could disable them?

**Before:**
![before](https://github.com/user-attachments/assets/dd20248f-9080-4b36-8ed9-b577ea22f91c)

**After:**
<img width="704" height="258" alt="image" src="https://github.com/user-attachments/assets/8a41135f-80c5-4628-8b1d-2551f31ff953" />

## Root cause

`drawDotMarkerToScreen` used `maxVal` as the scaling divisor instead of the actual range `(maxVal - minVal)`, and applied an extra `-1` offset to the row coordinate. Together these shifted every data point upward by one row relative to where the Y-axis labels said they should be. The braille renderer had the same off-by-one in `calcBraillePoint`.

## Fix

- Use the existing `calcDataPointHeight` helper (correct formula) in `drawDotMarkerToScreen` instead of the inline scaling expression
- Remove the `-1` row offset so data points land on the row their label value corresponds to
- Draw axes before data so data points on the axis row are not overwritten by the axis line character
- Fix strict bounds checks (`< y+height` → `<= y+height`) in both dot and braille renderers that were silently discarding minimum-value data points entirely
- Guard `calcDataPointHeight` against division by zero when `maxVal == minVal` (constant/flat dataset)
- Fix `GetPlotRect` to reduce height by 1 when axes are disabled, preventing minimum-value dots from drawing outside the widget boundary

## Improvements

While fixing the alignment, two additional UX improvements were made:

**Axis tick marks** — Y axis labels now have a `┤` tick on the axis line at the exact row the value corresponds to, and X axis labels have a `▾` triangle tick at the exact data point column. This removes the ambiguity of whether the top or bottom of a label corresponds to the value.

**X axis label centering** — the first label is anchored at its data point column (no left overflow), the last label omits its trailing gap (no right overflow), and intermediate label centering uses integer division instead of `math.Round` so each digit lands directly under its data point.